### PR TITLE
Fixing a small ommission in test-suite

### DIFF
--- a/word24.cabal
+++ b/word24.cabal
@@ -44,7 +44,8 @@ Test-Suite test
     word24,
     QuickCheck                 >= 2 && < 3,
     test-framework             >= 0.2 && < 0.9,
-    test-framework-quickcheck2 >= 0.2 && < 0.7
+    test-framework-quickcheck2 >= 0.2 && < 0.7,
+    word-compat                >= 0.0 && <0.1
 
 benchmark bench24
   default-language: Haskell2010


### PR DESCRIPTION
The import of word-compat is missing in test-suite